### PR TITLE
Open "/dev/null" instead of "/" because we may not have permission.

### DIFF
--- a/src/unix/stream.c
+++ b/src/unix/stream.c
@@ -88,7 +88,7 @@ void uv__stream_init(uv_loop_t* loop,
   stream->write_queue_size = 0;
 
   if (loop->emfile_fd == -1) {
-    err = uv__open_cloexec("/", O_RDONLY);
+    err = uv__open_cloexec("/dev/null", O_RDONLY);
     if (err >= 0)
       loop->emfile_fd = err;
   }


### PR DESCRIPTION
This fix allows `libuv` to be used in a Mac app that has sandboxing enabled, without the need for a temporary entitlement to allow reading of "/". (Which would never pass app review).

/cc @skabbes 
